### PR TITLE
Prevent reset hue value when a color is grayscale color

### DIFF
--- a/lib/BasicColorPanel.tsx
+++ b/lib/BasicColorPanel.tsx
@@ -20,6 +20,7 @@ export const BasicColorPanel: FC<BasicColorPanelProps> = ({
   color,
   onColorUpdate,
 }) => {
+  const [hue, setHue] = useState(color?.toHsl().h || 0);
   const [currentColor, setCurrentColor] = useState<TinyColorInstance>(color);
 
   useEffect(() => {
@@ -29,8 +30,18 @@ export const BasicColorPanel: FC<BasicColorPanelProps> = ({
     setCurrentColor(color);
   }, [color]);
 
+  useEffect(() => {
+    if (currentColor?.toHsv().s !== 0) {
+      setHue(currentColor.toHsv().h);
+    }
+  }, [currentColor]);
+
   const handleColorUpdate = useCallback(
     (colorData: ColorInputWithoutInstance) => {
+      if (typeof colorData === "object" && "h" in colorData) {
+        setHue(colorData.h);
+      }
+
       const col = tinycolor.fromRatio(colorData);
       if (!colorData || tinycolor.equals(col, currentColor)) {
         return;
@@ -44,13 +55,13 @@ export const BasicColorPanel: FC<BasicColorPanelProps> = ({
   const hsv = useMemo(
       () =>
         currentColor
-          ? currentColor.toHsv()
+          ? { ...currentColor.toHsv(), h: hue }
           : {
-              h: 0,
+              h: hue,
               s: 0,
               v: 0,
             },
-      [currentColor]
+      [currentColor, hue]
     ),
     rgb = useMemo(
       () =>

--- a/lib/HorizontalColorPanel.tsx
+++ b/lib/HorizontalColorPanel.tsx
@@ -56,6 +56,7 @@ export const HorizontalColorPanel: FC<HorizontalColorPanelProps> = ({
   onColorUpdate,
   children,
 }) => {
+  const [hue, setHue] = useState(color?.toHsl().h || 0);
   const [currentColor, setCurrentColor] = useState<TinyColorInstance>(color);
   const [format, setFormat] = useState<ColorTextFormat>("hex6");
 
@@ -65,6 +66,12 @@ export const HorizontalColorPanel: FC<HorizontalColorPanelProps> = ({
     }
     setCurrentColor(color);
   }, [color]);
+
+  useEffect(() => {
+    if (currentColor?.toHsv().s !== 0) {
+      setHue(currentColor.toHsv().h);
+    }
+  }, [currentColor]);
 
   const handleClick = useCallback(() => {
     setFormat(
@@ -87,6 +94,10 @@ export const HorizontalColorPanel: FC<HorizontalColorPanelProps> = ({
 
   const handleRawColorUpdate = useCallback(
     (colorData: ColorInputWithoutInstance) => {
+      if (typeof colorData === "object" && "h" in colorData) {
+        setHue(colorData.h);
+      }
+
       const col = tinycolor.fromRatio(colorData);
       if (!colorData || tinycolor.equals(col, currentColor)) {
         return;
@@ -100,13 +111,13 @@ export const HorizontalColorPanel: FC<HorizontalColorPanelProps> = ({
   const hsv = useMemo(
       () =>
         currentColor
-          ? currentColor.toHsv()
+          ? { ...currentColor.toHsv(), h: hue }
           : {
-              h: 0,
+              h: hue,
               s: 0,
               v: 0,
             },
-      [currentColor]
+      [currentColor, hue]
     ),
     rgb = useMemo(
       () =>


### PR DESCRIPTION
## Problem
When a user selects a grayscale color, or the passed argument is grayscale color, the hue value is lost. As a result, the user can't edit the hue value during the selected color is a grayscale color.

[![Image from Gyazo](https://i.gyazo.com/0d6ada67a5680e342c189187e667fd01.gif)](https://gyazo.com/0d6ada67a5680e342c189187e667fd01)

## Solution
To prevent resetting a hue value to zero, some components save the hue value when the next color is grayscale.

[![Image from Gyazo](https://i.gyazo.com/a88cdb8bddeb9f97a7577f178f087ea6.gif)](https://gyazo.com/a88cdb8bddeb9f97a7577f178f087ea6)
